### PR TITLE
fix: added missing trait bound to ParsePath implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub enum ParseError {
     By(String, Box<ParseError>),
     RemainingSegments,
 }
-impl<T: FromStr + ToString> ParsePath for T {
+impl<T: FromStr + ToString + AsPath> ParsePath for T {
     fn parse_path(path: &str) -> Result<Self, ParseError> {
         path.trim_start_matches("/").parse::<T>().map_err(|_| ParseError::FromStr)
     }


### PR DESCRIPTION
Hello,

My IDE told me that we are missing a trait bound.

![missing_trait_bound](https://user-images.githubusercontent.com/30114057/94678727-38fe6e00-031f-11eb-9e1f-8c8fafd651e0.png)


So I think it make sens since we require it in the trait definition.
